### PR TITLE
add trivial https server, add `--make_cert` command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ go.work.sum
 .env
 
 go-test-servers
+
+# generated pem files
+*.pem

--- a/certificates/generate.go
+++ b/certificates/generate.go
@@ -1,0 +1,234 @@
+package certificates
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"time"
+)
+
+// KeyType represents the type of key to generate (ECDSA or RSA).
+type KeyType int
+
+const (
+	ECDSA KeyType = iota
+	RSA
+)
+
+func ParseKeyType(keyType string) (KeyType, error) {
+	switch keyType {
+	case "RSA":
+		return RSA, nil
+	case "ECDSA":
+		return ECDSA, nil
+	default:
+		return ECDSA, fmt.Errorf("unsupported key type: %s", keyType)
+	}
+}
+
+func GenerateCertificates(keyType KeyType, expireAfter time.Duration, dnsNames, ipAddresses []string) error {
+	if len(dnsNames) == 0 {
+		dnsNames = []string{"localhost"}
+	}
+	if len(ipAddresses) == 0 {
+		ipAddresses = []string{"127.0.0.1", "::1"}
+	}
+	if expireAfter == 0 {
+		expireAfter = 365 * 24 * time.Hour
+	}
+
+	caCertPath := "ca.pem"
+	caKeyPath := "ca-key.pem"
+	serverCertPath := "server.pem"
+	serverKeyPath := "server-key.pem"
+	clientCertPath := "client.pem"
+	clientKeyPath := "client-key.pem"
+	serverChainPath := "server-chain.pem"
+	clientChainPath := "client-chain.pem"
+
+	paths := []string{caCertPath, caKeyPath, serverCertPath, serverKeyPath, clientCertPath, clientKeyPath, serverChainPath, clientChainPath}
+	for _, path := range paths {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to delete file %s: %v", path, err)
+		}
+	}
+
+	caCert, caKey, err := generateCertificate(keyType, []x509.ExtKeyUsage{x509.ExtKeyUsageAny, x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}, expireAfter, true, nil, nil, nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to generate CA certificate: %v", err)
+	}
+	if err := writeCertificateToFile(caCertPath, caKeyPath, caCert, caKey); err != nil {
+		return fmt.Errorf("failed to write CA certificate to file: %v", err)
+	}
+
+	serverCert, serverKey, err := generateCertificate(keyType, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth}, expireAfter, false, caCert, caKey, dnsNames, ipAddresses)
+	if err != nil {
+		return fmt.Errorf("failed to generate server certificate: %v", err)
+	}
+	if err := writeCertificateToFile(serverCertPath, serverKeyPath, serverCert, serverKey); err != nil {
+		return fmt.Errorf("failed to write server certificate to file: %v", err)
+	}
+
+	clientCert, clientKey, err := generateCertificate(keyType, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}, expireAfter, false, caCert, caKey, dnsNames, ipAddresses)
+	if err != nil {
+		return fmt.Errorf("failed to generate client certificate: %v", err)
+	}
+	if err := writeCertificateToFile(clientCertPath, clientKeyPath, clientCert, clientKey); err != nil {
+		return fmt.Errorf("failed to write client certificate to file: %v", err)
+	}
+
+	serverPem, err := os.ReadFile(serverCertPath)
+	if err != nil {
+		return fmt.Errorf("failed to read server.pem: %v", err)
+	}
+	caPem, err := os.ReadFile(caCertPath)
+	if err != nil {
+		return fmt.Errorf("failed to read ca.pem: %v", err)
+	}
+	err = os.WriteFile(serverChainPath, append(serverPem, caPem...), 0644)
+	if err != nil {
+		return fmt.Errorf("failed to write server-chain.pem: %v", err)
+	}
+
+	clientPem, err := os.ReadFile(clientCertPath)
+	if err != nil {
+		return fmt.Errorf("failed to read client.pem: %v", err)
+	}
+
+	err = os.WriteFile(clientChainPath, append(clientPem, caPem...), 0644)
+	if err != nil {
+		return fmt.Errorf("failed to write client-chain.pem: %v", err)
+	}
+
+	return nil
+}
+
+func generateCertificate(keyType KeyType, extKeyUsage []x509.ExtKeyUsage, expireAfter time.Duration, isCA bool, parentCert *x509.Certificate, parentKey interface{}, dnsNames, ipAddresses []string) (*x509.Certificate, interface{}, error) {
+	// Generate a private key
+	var priv interface{}
+	var err error
+	switch keyType {
+	case ECDSA:
+		priv, err = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	case RSA:
+		priv, err = rsa.GenerateKey(rand.Reader, 2048)
+	default:
+		return nil, nil, fmt.Errorf("unsupported key type")
+	}
+
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate private key: %v", err)
+	}
+
+	ips := make([]net.IP, len(ipAddresses))
+	for i, ip := range ipAddresses {
+		ips[i] = net.ParseIP(ip)
+	}
+
+	serialNumber, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate serial number: %v", err)
+	}
+
+	// Create a certificate template
+	template := x509.Certificate{
+		SerialNumber: serialNumber,
+		Subject: pkix.Name{
+			CommonName:   "Test Certificate",
+			Country:      []string{"US"},
+			Organization: []string{"Test Organization"},
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(expireAfter),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           extKeyUsage,
+		BasicConstraintsValid: true,
+		DNSNames:              dnsNames,
+		IPAddresses:           ips,
+	}
+
+	if isCA {
+		template.IsCA = true
+		template.KeyUsage |= x509.KeyUsageCertSign
+		// If the certificate CN matches the parent openssl will reject it, so choose unique CN for CA
+		template.Subject.CommonName = "Test CA Certificate"
+	}
+
+	// Use self-signed if no parent is provided
+	if parentCert == nil || parentKey == nil {
+		parentCert = &template
+		parentKey = priv
+	}
+
+	// Create the certificate
+	var pub interface{}
+	switch k := priv.(type) {
+	case *ecdsa.PrivateKey:
+		pub = &k.PublicKey
+	case *rsa.PrivateKey:
+		pub = &k.PublicKey
+	default:
+		return nil, nil, fmt.Errorf("unsupported key type")
+	}
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, &template, parentCert, pub, parentKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create certificate: %v", err)
+	}
+
+	cert, err := x509.ParseCertificate(certBytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse certificate: %v", err)
+	}
+
+	return cert, priv, nil
+}
+
+func writeCertificateToFile(certPath, keyPath string, cert *x509.Certificate, key interface{}) error {
+	// Write the certificate to a file
+	certFile, err := os.Create(certPath)
+	if err != nil {
+		return fmt.Errorf("failed to create cert file: %v", err)
+	}
+	defer certFile.Close()
+	if err := pem.Encode(certFile, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}); err != nil {
+		return fmt.Errorf("failed to write cert file: %v", err)
+	}
+
+	// Write the private key to a file
+	keyFile, err := os.Create(keyPath)
+	if err != nil {
+		return fmt.Errorf("failed to create key file: %v", err)
+	}
+	defer keyFile.Close()
+
+	var typeName string
+	var privBytes []byte
+	switch k := key.(type) {
+	case *ecdsa.PrivateKey:
+		privBytes, err = x509.MarshalECPrivateKey(k)
+		typeName = "EC PRIVATE KEY"
+	case *rsa.PrivateKey:
+		privBytes = x509.MarshalPKCS1PrivateKey(k)
+		typeName = "RSA PRIVATE KEY"
+	default:
+		return fmt.Errorf("unsupported key type")
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed to marshal private key: %v", err)
+	}
+	if err := pem.Encode(keyFile, &pem.Block{Type: typeName, Bytes: privBytes}); err != nil {
+		return fmt.Errorf("failed to write key file: %v", err)
+	}
+
+	return nil
+}

--- a/config.yaml
+++ b/config.yaml
@@ -17,7 +17,18 @@ servers:
     enabled: true
     host: 127.0.0.1
     port: 5002
-    certfile: "cert.pem"
-    keyfile: "key.pem"
+    certfile: "server-chain.pem"
+    keyfile: "server-key.pem"
     cafile: "ca.pem"
     handler: "echo"
+    minTlsVersion: "TLSv1.2"
+    maxTlsVersion: "TLSv1.3"
+    # Optional: Specify the cipher suites to use (applies only to TLSv1.2 or earlier)
+    # Note: TLSv1.3 does not allow specifying cipher suites
+    # https://pkg.go.dev/crypto/tls#pkg-constants
+    # test example:
+    # openssl s_client -connect 127.0.0.1:5002 -cert client.pem -key client-key.pem -CAfile ca.pem -tls1_2 -cipher TLS_RSA_WITH_AES_128_CBC_SHA
+    cipherSuites:
+      - "TLS_RSA_WITH_AES_128_CBC_SHA"
+      - "TLS_RSA_WITH_AES_256_CBC_SHA"
+      - "TLS_RSA_WITH_AES_128_GCM_SHA256"

--- a/config.yaml
+++ b/config.yaml
@@ -32,3 +32,18 @@ servers:
       - "TLS_RSA_WITH_AES_128_CBC_SHA"
       - "TLS_RSA_WITH_AES_256_CBC_SHA"
       - "TLS_RSA_WITH_AES_128_GCM_SHA256"
+
+  - type: "https"
+    enabled: true
+    host: 127.0.0.1
+    port: 5003
+    certfile: "server-chain.pem"
+    keyfile: "server-key.pem"
+    cafile: "ca.pem"
+    minTlsVersion: "TLSv1.0"
+    maxTlsVersion: "TLSv1.2"
+    # Optional: Specify the cipher suites to use (applies only to TLSv1.2 or earlier)
+    cipherSuites:
+      - "TLS_RSA_WITH_AES_128_CBC_SHA"
+      - "TLS_RSA_WITH_AES_256_CBC_SHA"
+      - "TLS_RSA_WITH_AES_128_GCM_SHA256"

--- a/config.yaml
+++ b/config.yaml
@@ -47,3 +47,8 @@ servers:
       - "TLS_RSA_WITH_AES_128_CBC_SHA"
       - "TLS_RSA_WITH_AES_256_CBC_SHA"
       - "TLS_RSA_WITH_AES_128_GCM_SHA256"
+    curveTypes:
+      - "P256"
+      - "P384"
+      - "P521"
+      - "X25519"

--- a/config/cipher_suite.go
+++ b/config/cipher_suite.go
@@ -1,0 +1,40 @@
+package config
+
+import (
+	"crypto/tls"
+	"fmt"
+)
+
+// ParseCipherSuite converts a cipher suite name to its corresponding constant.
+func ParseCipherSuite(cipher string) (uint16, error) {
+	switch cipher {
+	case "TLS_RSA_WITH_AES_128_CBC_SHA":
+		return tls.TLS_RSA_WITH_AES_128_CBC_SHA, nil
+	case "TLS_RSA_WITH_AES_256_CBC_SHA":
+		return tls.TLS_RSA_WITH_AES_256_CBC_SHA, nil
+	case "TLS_RSA_WITH_AES_128_GCM_SHA256":
+		return tls.TLS_RSA_WITH_AES_128_GCM_SHA256, nil
+	case "TLS_RSA_WITH_AES_256_GCM_SHA384":
+		return tls.TLS_RSA_WITH_AES_256_GCM_SHA384, nil
+	case "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA":
+		return tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA, nil
+	case "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA":
+		return tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA, nil
+	case "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256":
+		return tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, nil
+	case "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384":
+		return tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384, nil
+	case "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256":
+		return tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256, nil
+	case "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384":
+		return tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384, nil
+	case "TLS_AES_128_GCM_SHA256":
+		return tls.TLS_AES_128_GCM_SHA256, nil
+	case "TLS_AES_256_GCM_SHA384":
+		return tls.TLS_AES_256_GCM_SHA384, nil
+	case "TLS_CHACHA20_POLY1305_SHA256":
+		return tls.TLS_CHACHA20_POLY1305_SHA256, nil
+	default:
+		return 0, fmt.Errorf("unsupported cipher suite: %s", cipher)
+	}
+}

--- a/config/cipher_suite.go
+++ b/config/cipher_suite.go
@@ -38,3 +38,18 @@ func ParseCipherSuite(cipher string) (uint16, error) {
 		return 0, fmt.Errorf("unsupported cipher suite: %s", cipher)
 	}
 }
+
+func ParseCurveType(curveType string) (tls.CurveID, error) {
+	switch curveType {
+	case "P256":
+		return tls.CurveP256, nil
+	case "P384":
+		return tls.CurveP384, nil
+	case "P521":
+		return tls.CurveP521, nil
+	case "X25519":
+		return tls.X25519, nil
+	default:
+		return 0, fmt.Errorf("unsupported curve type: %s", curveType)
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -38,6 +38,7 @@ type ServerConfig struct {
 	MinTlsVersion string   `yaml:"minTlsVersion"`
 	MaxTlsVersion string   `yaml:"maxTlsVersion"`
 	CipherSuites  []string `yaml:"cipherSuites"`
+	CurveTypes    []string `yaml:"curveTypes"`
 }
 
 type Config struct {

--- a/config/config.go
+++ b/config/config.go
@@ -13,16 +13,16 @@ type HandlerType string
 const (
 	Socket ServerType = "socket"
 	Socks5 ServerType = "socks5"
-	Ssl ServerType = "ssl-socket"
+	Ssl    ServerType = "ssl-socket"
 
 	Echo HandlerType = "echo"
 )
 
 type ServerConfig struct {
-	Type ServerType `yaml:"type"`
-	Enabled bool `yaml:"enabled"`
-	Host string `yaml:"host"`
-	Port int `yaml:"port"`
+	Type        ServerType  `yaml:"type"`
+	Enabled     bool        `yaml:"enabled"`
+	Host        string      `yaml:"host"`
+	Port        int         `yaml:"port"`
 	HandlerType HandlerType `yaml:"handler"`
 
 	// Socks5 specific
@@ -31,9 +31,12 @@ type ServerConfig struct {
 	Protocol string `yaml:"protocol"`
 
 	// Ssl specific
-	Cert string `yaml:"certfile"`
-	Key string `yaml:"keyfile"`
-	Ca string `yaml:"cafile"`
+	Cert          string   `yaml:"certfile"`
+	Key           string   `yaml:"keyfile"`
+	Ca            string   `yaml:"cafile"`
+	MinTlsVersion string   `yaml:"minTlsVersion"`
+	MaxTlsVersion string   `yaml:"maxTlsVersion"`
+	CipherSuites  []string `yaml:"cipherSuites"`
 }
 
 type Config struct {

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ const (
 	Socket ServerType = "socket"
 	Socks5 ServerType = "socks5"
 	Ssl    ServerType = "ssl-socket"
+	Https  ServerType = "https"
 
 	Echo HandlerType = "echo"
 )

--- a/config/tls_version.go
+++ b/config/tls_version.go
@@ -1,0 +1,22 @@
+package config
+
+import (
+	"crypto/tls"
+	"fmt"
+)
+
+// ParseTlsVersion converts a TLS version string to its corresponding constant.
+func ParseTlsVersion(version string) (uint16, error) {
+	switch version {
+	case "TLSv1.0":
+		return tls.VersionTLS10, nil
+	case "TLSv1.1":
+		return tls.VersionTLS11, nil
+	case "TLSv1.2":
+		return tls.VersionTLS12, nil
+	case "TLSv1.3":
+		return tls.VersionTLS13, nil
+	default:
+		return 0, fmt.Errorf("unsupported TLS version: %s", version)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ func main() {
 	os.Chdir(thisDir)
 
 	configPath := flag.String("config", "config.yaml", "path to the config file")
-	generateCertificates := flag.String("make_cert", "", "certificate type to generate (RSA, ECDSA)")
+	generateCertificates := flag.String("make_cert", "", "generate certificate [RSA, ECDSA]")
 
 	flag.Parse()
 
@@ -45,6 +45,7 @@ func main() {
 			log.Fatalf("Error generating certificates: %v", err)
 		}
 		log.Printf("Certificates generated successfully")
+		os.Exit(0)
 	}
 
 	serverConfig := config.Config{}

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"os/signal"
 	"path/filepath"
 
+	"go-test-servers/certificates"
 	"go-test-servers/config"
 	"go-test-servers/servers"
 )
@@ -30,7 +31,21 @@ func main() {
 	os.Chdir(thisDir)
 
 	configPath := flag.String("config", "config.yaml", "path to the config file")
+	generateCertificates := flag.String("make_cert", "", "certificate type to generate (RSA, ECDSA)")
+
 	flag.Parse()
+
+	if *generateCertificates != "" {
+		keyType, err := certificates.ParseKeyType(*generateCertificates)
+		if err != nil {
+			log.Fatalf("Invalid certificate type: %v", err)
+		}
+		err = certificates.GenerateCertificates(keyType, 0, nil, nil)
+		if err != nil {
+			log.Fatalf("Error generating certificates: %v", err)
+		}
+		log.Printf("Certificates generated successfully")
+	}
 
 	serverConfig := config.Config{}
 	serverConfig.ReadConfig(configPath)

--- a/servers/servers.go
+++ b/servers/servers.go
@@ -2,12 +2,12 @@ package servers
 
 import (
 	"fmt"
-	"log"
 	"go-test-servers/config"
+	"log"
 )
 
 func StartServer(cfg config.ServerConfig) error {
-	defer func () {
+	defer func() {
 		// ensure a new line, even if we return early from error
 		fmt.Println()
 	}()
@@ -22,8 +22,8 @@ func StartServer(cfg config.ServerConfig) error {
 		go RunTcpSocketServer(cfg, status)
 	case config.Socks5:
 		go RunSocksServer(cfg, status)
-	case config.Ssl:
-		go RunSslSocketServer(cfg, status)
+	case config.Ssl, config.Https:
+		go RunTlsServer(cfg, status)
 	default:
 		log.Printf("Unknown server type: %s\n", cfg.Type)
 		return fmt.Errorf("unknown server type: %s", cfg.Type)

--- a/servers/ssl.go
+++ b/servers/ssl.go
@@ -108,12 +108,26 @@ func RunTlsServer(cfg config.ServerConfig, status chan bool) {
 		}
 	}
 
+	var curveTypes []tls.CurveID = nil
+	if cfg.CurveTypes != nil {
+		curveTypes = make([]tls.CurveID, len(cfg.CurveTypes))
+		for i, curve := range cfg.CurveTypes {
+			curveTypes[i], err = config.ParseCurveType(curve)
+			if err != nil {
+				log.Printf("Failed to parse curve type: %s", curve)
+				status <- false
+				return
+			}
+		}
+	}
+
 	tlsConfig := &tls.Config{
-		RootCAs:      rootCAs,
-		Certificates: []tls.Certificate{pair},
-		MinVersion:   minTlsVersion,
-		MaxVersion:   maxTlsVersion,
-		CipherSuites: cipherSuites,
+		RootCAs:          rootCAs,
+		Certificates:     []tls.Certificate{pair},
+		MinVersion:       minTlsVersion,
+		MaxVersion:       maxTlsVersion,
+		CipherSuites:     cipherSuites,
+		CurvePreferences: curveTypes,
 	}
 
 	address := fmt.Sprintf("%s:%d", cfg.Host, cfg.Port)


### PR DESCRIPTION
Add `--make_cert` command to generate RSA or ECDSA certificates for the test servers.

Add trivial https server.

The certificate generation can be further parametrized, perhaps via config file similar to Certificate Signing Request config when using OpenSSL. For now it assumes defaults, generating certificates for localhost.